### PR TITLE
chore: migrate prefs.ini from services-test

### DIFF
--- a/prefs.ini
+++ b/prefs.ini
@@ -1,0 +1,42 @@
+# see: https://github.com/jrgm/fxa-release-status
+
+[DEFAULT]
+browser.displayedE10SNotice = 4
+browser.startup.homepage = http://localhost:8000
+browser.startup.homepage_override.mstone = ignore
+browser.startup.page = 1
+browser.tabs.remote.autostart = false
+browser.tabs.remote.autostart.1 = false
+browser.tabs.remote.autostart.2 = false
+browser.tabs.remote.autostart.3 = false
+
+[dev]
+dom.push.serverURL = wss://autopush.dev.mozaws.net/
+
+[stage]
+dom.push.serverURL = wss://autopush.stage.mozaws.net/
+identity.fxaccounts.auth.uri = https://api-accounts.stage.mozaws.net/v1
+identity.fxaccounts.remote.force_auth.uri = https://accounts.stage.mozaws.net/force_auth?service=sync&context=fx_desktop_v3 
+identity.fxaccounts.remote.oauth.uri = https://oauth.stage.mozaws.net/v1
+identity.fxaccounts.remote.profile.uri = https://profile.stage.mozaws.net/v1 
+identity.fxaccounts.remote.signin.uri = https://accounts.stage.mozaws.net/signin?service=sync&context=fx_desktop_v3 
+identity.fxaccounts.remote.signup.uri = https://accounts.stage.mozaws.net/signup?service=sync&context=fx_desktop_v3 
+identity.fxaccounts.remote.webchannel.uri = https://accounts.stage.mozaws.net/ 
+identity.fxaccounts.settings.devices.uri = https://accounts.stage.mozaws.net/settings/clients?service=sync&context=fx_desktop_v3 
+identity.fxaccounts.settings.uri =  https://accounts.stage.mozaws.net/settings?service=sync&context=fx_desktop_v3
+services.sync.fxa.privacyURL = https://accounts.stage.mozaws.net/legal/privacy 
+services.sync.fxa.termsURL = https://accounts.stage.mozaws.net/legal/terms
+
+[prod]
+dom.push.serverURL = wss://push.services.mozilla.com/
+identity.fxaccounts.auth.uri = https://api.accounts.firefox.com/v1
+identity.fxaccounts.remote.force_auth.uri = https://accounts.firefox.com/force_auth?service=sync&context=fx_desktop_v3 
+identity.fxaccounts.remote.oauth.uri = https://oauth.accounts.firefox.com/v1
+identity.fxaccounts.remote.profile.uri = https://profile.accounts.firefox.com/v1 
+identity.fxaccounts.remote.signin.uri = https://accounts.firefox.com/signin?service=sync&context=fx_desktop_v3 
+identity.fxaccounts.remote.signup.uri = https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3 
+identity.fxaccounts.remote.webchannel.uri = https://accounts.firefox.com/ 
+identity.fxaccounts.settings.devices.uri = https://accounts.firefox.com/settings/clients?service=sync&context=fx_desktop_v3 
+identity.fxaccounts.settings.uri =  https://accounts.firefox.com/settings?service=sync&context=fx_desktop_v3
+services.sync.fxa.privacyURL = https://accounts.firefox.com/legal/privacy 
+services.sync.fxa.termsURL = https://accounts.firefox.com/legal/terms


### PR DESCRIPTION
r? @chartjes 
Moving prefs.ini from mozilla-services/services-test (autopush) to here.

I will temporarily also check in this updated file to services-test, since ff-tool will need a slight modification. this will be the canonical prefs.ini for autopush automation, however, going forward.

Closes #37 